### PR TITLE
Add site metadata to entry proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+public/
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
+  - "5.1"
+  - "5.0"
+services:
+  - redis-server
 # Addons will be installed prior to the build phase.
 # Per Travis instructions here: http://docs.travis-ci.com/user/apt/
 addons:
@@ -10,4 +11,3 @@ addons:
     packages:
       - protobuf-compiler
       - libprotobuf-dev
-      - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ addons:
     packages:
       - protobuf-compiler
       - libprotobuf-dev
+      - build-essential

--- a/bouncer.js
+++ b/bouncer.js
@@ -50,6 +50,10 @@ function router(request, response) {
         routes.create(request, response, function (resp) {
             resp.end();
         });
+    } else if (path.pathname.indexOf("/debug") === 0) {
+        routes.debug(request, response, function (resp) {
+            resp.end();
+        });
         // Any time a shortlink is provided
         //   Ex: http://localhost/myfavoritelink
     } else {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "bouncer.js",
   "dependencies": {
     "async": "~1.4.2",
+    "cheerio": "^0.19.0",
     "gulp-jslint": "^0.2.2",
     "handlebars": "~4.0.1",
     "mocha": "~2.3.0",
     "node-normalize-scss": "^1.0.3",
     "node-protobuf": "~1.2.7",
-    "redis": "~1.0.0"
+    "redis": "~1.0.0",
+    "request": "^2.67.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/proto/entry.desc
+++ b/proto/entry.desc
@@ -1,7 +1,9 @@
 
-X
-proto/entry.protobouncer":
+w
+proto/entry.protobouncer"Y
 Entry
 	shortlink (	
 url (	
-	createdOn (
+	createdOn (
+domain (	
+title (	

--- a/proto/entry.proto
+++ b/proto/entry.proto
@@ -4,4 +4,6 @@ message Entry {
 	optional string shortlink = 1;
 	optional string url = 2;
 	optional uint64 createdOn = 3;
+    optional string domain = 4;
+    optional string title = 5;
 }

--- a/style/layout.scss
+++ b/style/layout.scss
@@ -22,4 +22,6 @@ body {
 .shortlink_block {
     display: inline-block;
     width: 15%;
+    min-width: 200px;
+    margin-bottom: 1%;
 }

--- a/style/theme.scss
+++ b/style/theme.scss
@@ -69,3 +69,7 @@ ul {
         color: white;
     }
 }
+
+.sl_domain {
+    font-style: italic;
+}

--- a/templates/main.html
+++ b/templates/main.html
@@ -21,8 +21,8 @@
         {{#each shortlinks}}
         <li class="shortlink_block">
             <a href="{{this.url}}"><h3>{{this.shortlink}}</h3></a>
-            <p class="sl_title">Page title</p>
-            <p class="sl_domain">Domain</p>
+            <p class="sl_domain">{{this.domain}}</p>
+            <p class="sl_title">{{this.title}}</p>
         </li>
         {{/each}}
     </ul>

--- a/test/util.js
+++ b/test/util.js
@@ -3,65 +3,71 @@ var util = require("../util");
 
 // TODO: cleanup task that gets rid of all keys that are created for tests.
 function clean(keys) {
-	// TODO: redis drop all keys listed in 'affected_keys'.
+    // TODO: redis drop all keys listed in 'affected_keys'.
 }
 
-describe("util.js", function() {
-	var affected_keys = [];
+describe("util.js", function () {
+    var affected_keys = [];
 
-	describe("#create", function() {
-		it("created object has all expected fields set", function() {
-			var shortlink = "goo";
-			var url = "https://google.com";
+    describe("#create", function () {
+        it("created object has all expected fields set", function () {
+            var shortlink = "goo";
+            var url = "https://google.com";
 
-			var entry = util.create(shortlink, url);			
-//			affected_keys.push(shortlink);
+            var entry = util.create({
+                shortlink: shortlink,
+                url: url,
+            }, function (newest) {
+                assert.equal(true, (newest.shortlink == shortlink && newest.url == url && newest.createdOn > 0));
+            });
+        });
 
-			assert.equal(true, (entry.shortlink == shortlink && entry.url == url && entry.createdOn > 0));
-		});
+        // Clean up affected keys.
+        affected_keys = clean(affected_keys);
 
-		// Clean up affected keys.
-		affected_keys = clean(affected_keys);
+        it("trying to create a shortlink with no url fails", function () {
+            var shortlink = "car";
 
-		it("trying to create a shortlink with no url fails", function() {
-			var shortlink = "car";
+            /*
+            try {
+                var entry = util.create(shortlink, null);
+                assert.equal(true, false);
+            } catch (e) {
+                if (e.name == "AssertionError") throw e;
+                else assert.equal(true, true);
+            }
+            */
+        });
 
-			try {
-				var entry = util.create(shortlink, null);
-				assert.equal(true, false);
-			} catch (e) {
-				if (e.name == "AssertionError") throw e;
-				else assert.equal(true, true);
-			}
-		});
+        // Clean up affected keys.
+        affected_keys = clean(affected_keys);
 
-		// Clean up affected keys.
-		affected_keys = clean(affected_keys);
+        it("trying to create a shortlink with no shortlink fails", function () {
+            /*
+            try {
+                var entry = util.create(null, "https://google.com");
+                assert.equal(true, false);
+            } catch (e) {
+                if (e.name == "AssertionError") throw e;
+                else assert.equal(true, true);
+            }
+            */
+        });
 
-		it("trying to create a shortlink with no shortlink fails", function() {
-			try {
-				var entry = util.create(null, "https://google.com");
-				assert.equal(true, false);
-			} catch (e) {
-				if (e.name == "AssertionError") throw e;
-				else assert.equal(true, true);
-			}
-		});
+        // Clean up affected keys.
+        affected_keys = clean(affected_keys);
+    });
 
-		// Clean up affected keys.
-		affected_keys = clean(affected_keys);
-	});
+    describe("#get", function () {
+        it("no matching shortlink returns no error && null", function () {
+            // Try to retrieve a key that's very unlikely to exist.
+            util.get("a;oewjaegfkjdsalfhds", function (err, val) {
+                assert.equal(true, (err == null && val == null));
+            })
+        });
 
-	describe("#get", function() {
-		it("no matching shortlink returns no error && null", function() {
-			// Try to retrieve a key that's very unlikely to exist.
-			util.get("a;oewjaegfkjdsalfhds", function(err, val) {
-				assert.equal(true, (err == null && val == null));
-			})
-		});
+        it("matching shortlink returns valid entry object", function () {
 
-		it("matching shortlink returns valid entry object", function() {
-
-		});
-	});
+        });
+    });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -1,73 +1,112 @@
 var assert = require("assert");
 var util = require("../util");
-
-// TODO: cleanup task that gets rid of all keys that are created for tests.
-function clean(keys) {
-    // TODO: redis drop all keys listed in 'affected_keys'.
-}
+var redis = require("redis");
 
 describe("util.js", function () {
-    var affected_keys = [];
+    var client;
+
+    // Initialize a Redis client connection to localhost before running any
+    // tests.
+    before('initialize redis client', function () {
+        client = redis.createClient();
+    });
+
+    // Once all tests are completed, remove everything in the testing keyspace
+    // (test:*).
+    after('teardown redis client', function (done) {
+        client.keys("test:*", function (error, results) {
+            client.del(results);
+            done();
+        });
+    });
 
     describe("#create", function () {
-        it("created object has all expected fields set", function () {
-            var shortlink = "goo";
+        it("created object has all expected fields set", function (done) {
+            var shortlink = "test:goo";
             var url = "https://google.com";
 
             var entry = util.create({
                 shortlink: shortlink,
                 url: url,
             }, function (newest) {
-                assert.equal(true, (newest.shortlink == shortlink && newest.url == url && newest.createdOn > 0));
+                assert.equal(true,
+                    newest.shortlink == shortlink &&
+                    newest.url == url &&
+                    newest.createdOn > 0 &&
+                    newest.domain == "google.com" &&
+                    newest.title !== "Unknown");
+
+                done();
             });
         });
 
-        // Clean up affected keys.
-        affected_keys = clean(affected_keys);
+        it("trying to create a shortlink with no url fails", function (done) {
+            var shortlink = "test:car";
 
-        it("trying to create a shortlink with no url fails", function () {
-            var shortlink = "car";
-
-            /*
             try {
-                var entry = util.create(shortlink, null);
-                assert.equal(true, false);
+                var entry = util.create({
+                    shortlink: shortlink,
+                }, function (newest) {
+                    assert.equal(true, false);
+                    done();
+                });
             } catch (e) {
                 if (e.name == "AssertionError") throw e;
                 else assert.equal(true, true);
+                done();
             }
-            */
         });
 
-        // Clean up affected keys.
-        affected_keys = clean(affected_keys);
-
-        it("trying to create a shortlink with no shortlink fails", function () {
-            /*
+        it("trying to create a shortlink with no shortlink fails", function (done) {
             try {
-                var entry = util.create(null, "https://google.com");
-                assert.equal(true, false);
+                var entry = util.create({
+                    url: "https://google.com",
+                }, function (newest) {
+                    assert.equal(true, false);
+                    done();
+                });
             } catch (e) {
                 if (e.name == "AssertionError") throw e;
                 else assert.equal(true, true);
+                done();
             }
-            */
         });
 
-        // Clean up affected keys.
-        affected_keys = clean(affected_keys);
+        it("trying to create a shortlink with no info fails", function (done) {
+            try {
+                var entry = util.create({}, function (newest) {
+                    assert.equal(true, false);
+                    done()
+                });
+            } catch (e) {
+                if (e.name == "AssertionError") throw e;
+                else assert.equal(true, true);
+                done();
+            }
+        });
     });
 
     describe("#get", function () {
         it("no matching shortlink returns no error && null", function () {
             // Try to retrieve a key that's very unlikely to exist.
-            util.get("a;oewjaegfkjdsalfhds", function (err, val) {
+            util.get("test:doesNotExist", function (err, val) {
                 assert.equal(true, (err == null && val == null));
             })
         });
 
-        it("matching shortlink returns valid entry object", function () {
+        it("matching shortlink returns valid entry object", function (done) {
+            var shortlink = "test:mail";
+            var url = "https://mail.google.com";
+            util.create({
+                shortlink: shortlink,
+                url: url,
+            }, function (newest) {
+                assert.equal(true,
+                    newest.shortlink === shortlink &&
+                    newest.url === url);
 
+                done();
+            });
         });
     });
 });

--- a/util.js
+++ b/util.js
@@ -25,6 +25,7 @@ var Entry = {
         var newest = {
             shortlink: entry.shortlink,
             url: entry.url,
+            createdOn: Date.now(),
             domain: function (url) {
                 return URL.parse(url).hostname;
             }(entry.url),
@@ -32,14 +33,14 @@ var Entry = {
         };
 
         request(entry.url, function (error, response, body) {
-            if (response.statusCode == 200) {
+            if (response !== undefined && response.statusCode == 200) {
                 var doc = cheerio.load(body, {
                     decodeEntities: true,
                 });
                 console.log(doc('title').text());
                 newest.title = doc('title').text().replace(/[^\x00-\x7F]/g, "");
             } else {
-                console.log("[EntryLookup] Specified URL doesn't exist: " + url);
+                console.log("[EntryLookup] Specified URL doesn't exist: " + entry.url);
                 newest.title = "Unknown";
             }
 
@@ -59,6 +60,7 @@ exports.create = function (entry, callback) {
 
     Entry.new(entry, function (newest) {
         // Store the new object.
+        // TODO: only create a single client (I think this is currently one connection per request).
         var client = redis.createClient();
         client.set(newest.shortlink, entryPb.serialize(newest, "bouncer.Entry"));
 

--- a/util.js
+++ b/util.js
@@ -4,6 +4,9 @@ var redis = require("redis");
 var protobuf = require("node-protobuf");
 var fs = require("fs");
 var async = require("async");
+var URL = require("url");
+var request = require("request");
+var cheerio = require("cheerio");
 
 /**
  * Core utility functionality that's invoked by request handlers in the main app. Note
@@ -12,32 +15,55 @@ var async = require("async");
  * util.js so that the rest of the app doesn't need to be aware and some of this stuff
  * can change if needed.
  */
-
-exports.stub = function (shortlink, url) {
-    return new Entry(shortlink, url);
-};
-
-function Entry(shortlink, url) {
-    if (shortlink == null) throw Error("You must provide a shortlink name.");
-    if (url == null) throw Error("You must provide a URL for the shortlink.");
-
-    this.shortlink = shortlink;
-    this.url = url;
-    this.createdOn = Date.now();
-};
-
 var entryPb = new protobuf(fs.readFileSync("./proto/entry.desc"));
+
+var Entry = {
+    new: function (entry, callback) {
+        if (entry.shortlink === null) throw Error("You must provide a shortlink name.");
+        if (entry.url === null) throw Error("You must provide a URL for the shortlink.");
+
+        var newest = {
+            shortlink: entry.shortlink,
+            url: entry.url,
+            domain: function (url) {
+                return URL.parse(url).hostname;
+            }(entry.url),
+            title: null,
+        };
+
+        request(entry.url, function (error, response, body) {
+            if (response.statusCode == 200) {
+                var doc = cheerio.load(body, {
+                    decodeEntities: true,
+                });
+                console.log(doc('title').text());
+                newest.title = doc('title').text().replace(/[^\x00-\x7F]/g, "");
+            } else {
+                console.log("[EntryLookup] Specified URL doesn't exist: " + url);
+                newest.title = "Unknown";
+            }
+
+            callback(newest);
+        });
+    },
+};
 
 /**
  * Create a new shortlink.
  */
-exports.create = function (shortlink, url) {
-    var entry = new Entry(shortlink, url);
-    var client = redis.createClient();
+exports.create = function (entry, callback) {
+    // Check to make sure the entry contains critical fields.
+    if (entry === null || entry === undefined) throw Error("No entry data provided");
+    if (entry.shortlink === null || entry.shortlink === undefined) throw Error("You must provide a shortlink name.");
+    if (entry.url === null || entry === undefined) throw Error("You must provide a URL for the shortlink.");
 
-    client.set(shortlink, entryPb.serialize(entry, "bouncer.Entry"));
+    Entry.new(entry, function (newest) {
+        // Store the new object.
+        var client = redis.createClient();
+        client.set(newest.shortlink, entryPb.serialize(newest, "bouncer.Entry"));
 
-    return entry;
+        callback(newest);
+    });
 }
 
 /**


### PR DESCRIPTION
This PR adds `title` and `domain` fields to the entry proto, which are populated at creation time. The domain is the hostname, extracted directly from the provided URL, and the title is the value of the `<title>` element. The latter requires a GET request to the destination server, which means there's some added latency (exact amount is highly dependent on the URL).
